### PR TITLE
リンクの修正

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](../LICENSE)
-[![Not use](https://img.shields.io/badge/Framework-Not_use-blue.svg)](https://nodejs.org/ja/)
+[![Not use](https://img.shields.io/badge/Framework-Not_use-blue.svg)](https://www.php.net/)
 ![hidao quality](https://img.shields.io/badge/hidao-quality-orange.svg)
 
 ## url_shortener is 何

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-[![MIT license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE.md)
+[![MIT license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](../LICENSE)
 [![Not use](https://img.shields.io/badge/Framework-Not_use-blue.svg)](https://nodejs.org/ja/)
 ![hidao quality](https://img.shields.io/badge/hidao-quality-orange.svg)
 


### PR DESCRIPTION
余計なお世話かもしれませんが

* ライセンスへのリンクが 404 になっていた
* Framework へのリンクが node.js になっていた→php が正しい？

を修正しました。

また、ほかに気になる点としては `README.md` の記載で

> `index.php`と`hash.php`の`$base_url`の値を`index.php`へのURLにします。

とありますが `index.php` の  `$base_url` は書き換えが不要ではないかと思うのですが、どうでしょうか？
（修正はしていません）